### PR TITLE
Attempt to allow DComp in Windows 8.1

### DIFF
--- a/gfx/config/gfxConfigManager.cpp
+++ b/gfx/config/gfxConfigManager.cpp
@@ -60,6 +60,7 @@ void gfxConfigManager::Init() {
 #ifdef XP_WIN
   DeviceManagerDx::Get()->CheckHardwareStretchingSupport(mHwStretchingSupport);
   mScaledResolution = HasScaledResolution();
+  mIsWin8Point1OrLater = IsWin8Point1OrLater();
   mIsWin10OrLater = IsWin10OrLater();
   mIsWin11OrLater = IsWin11OrLater();
   mWrCompositorDCompRequired = true;
@@ -262,11 +263,10 @@ void gfxConfigManager::ConfigureWebRender() {
                                  "FEATURE_FAILURE_DCOMP_PREF_DISABLED"_ns);
   }
 
-  if (!mIsWin10OrLater) {
-    // XXX relax win version to windows 8.
+  if (!mIsWin8Point1OrLater) {
     mFeatureWrDComp->Disable(FeatureStatus::Unavailable,
-                             "Requires Windows 10 or later",
-                             "FEATURE_FAILURE_DCOMP_NOT_WIN10"_ns);
+                             "Requires Windows 8.1 or later",
+                             "FEATURE_FAILURE_DCOMP_NOT_WIN8.1"_ns);
   }
 
   if (!mFeatureGPUProcess->IsEnabled()) {

--- a/gfx/config/gfxConfigManager.h
+++ b/gfx/config/gfxConfigManager.h
@@ -109,6 +109,7 @@ class gfxConfigManager {
   bool mIsNightly;
   bool mIsEarlyBetaOrEarlier;
   bool mSafeMode;
+  bool mIsWin8Point1OrLater;
   bool mIsWin10OrLater;
   bool mIsWin11OrLater;
 };


### PR DESCRIPTION
This attempts to allow Direct Composition to be enabled in Windows 8.1 (not 8.0 since it seems to lack a required API) as by default it's forced off instead of allowing the user to choose via `gfx.webrender.dcomp-win.enabled`.

Sadly I was not able to test this since I do not have the requisite setup to compile and test this change but in theory this should work fine.